### PR TITLE
switch to dlmalloc (default allocator for wasm32)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ dependencies = [
  "aidoku_imports",
  "aidoku_macros",
  "aidoku_proc_macros",
- "wee_alloc",
+ "dlmalloc",
 ]
 
 [[package]]
@@ -38,10 +38,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "cfg-if"
-version = "0.1.10"
+name = "dlmalloc"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+checksum = "203540e710bfadb90e5e29930baf5d10270cec1f43ab34f46f78b147b2de715a"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "example_source"
@@ -52,15 +55,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.121"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
-
-[[package]]
-name = "memory_units"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "proc-macro2"
@@ -96,37 +93,3 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
-name = "wee_alloc"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb3b5a6b2bb17cb6ad44a2e68a43e8d2722c997da10e928665c72ec6c0a0b8e"
-dependencies = [
- "cfg-if",
- "libc",
- "memory_units",
- "winapi",
-]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/crates/helpers/src/node.rs
+++ b/crates/helpers/src/node.rs
@@ -3,7 +3,7 @@ use alloc::string::String;
 
 pub trait NodeHelpers {
     /// Get the text of the element and its children. It's different from
-    /// [aidoku_imports::Node::text] in that `<p>` and `<br>` are considered
+    /// [aidoku_imports::html::Node::text] in that `<p>` and `<br>` are considered
     /// and will insert linebreaks.
     fn text_with_newlines(&self) -> String;
 }

--- a/crates/helpers/src/uri.rs
+++ b/crates/helpers/src/uri.rs
@@ -138,7 +138,7 @@ impl QueryParameters {
     /// Remove all query parameters matching given pre-encoded name.
     pub fn remove_all_encoded<T: AsRef<str>>(&mut self, name: T) {
         let name = name.as_ref();
-        self.params.retain(|&(ref n, _)| n != name);
+        self.params.retain(|(n, _)| n != name);
     }
 }
 

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -8,9 +8,9 @@ publish = true
 aidoku_imports = { path = "../imports" }
 aidoku_macros = { path = "../macros" }
 aidoku_proc_macros = { path = "../proc_macros" }
-wee_alloc = { version = "0.4.5", optional = true }
+dlmalloc = { version = "0.2.4", optional = true, features = ["global"] }
 aidoku_helpers = { path = "../helpers", optional = true }
 
 [features]
-default = ["wee_alloc"]
+default = ["dlmalloc"]
 helpers = ["aidoku_helpers"]

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -9,11 +9,8 @@
 
 // Setup allocator
 
-#[cfg(feature = "wee_alloc")]
-extern crate wee_alloc;
-
-#[cfg_attr(feature = "wee_alloc", global_allocator)]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+#[cfg_attr(feature = "dlmalloc", global_allocator)]
+static ALLOCATOR: dlmalloc::GlobalDlmalloc = dlmalloc::GlobalDlmalloc;
 
 // Set panic handlers
 


### PR DESCRIPTION
`wee_alloc` is slow, [unmaintained](https://github.com/advisories/GHSA-rc23-xxgq-x27g) and [leaks memory](https://github.com/rustwasm/wee_alloc/issues/106)